### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -6,6 +6,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  actions: write
 
 jobs:
   cleanup:


### PR DESCRIPTION
Potential fix for [https://github.com/dallay/hatchgrid/security/code-scanning/1](https://github.com/dallay/hatchgrid/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's functionality, it interacts with GitHub Actions caches using the `gh actions-cache` commands. This requires the `actions: write` permission to delete caches. No other permissions appear necessary for this workflow.

The `permissions` block will be added at the root level of the workflow file, ensuring it applies to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
