### PR TITLE
chore: Pin GitHub Actions to commit SHAs for improved security

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew test
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@afb2984f4d89672b2f9d9c13ae23d53779671984 # v2.19.0
         if: always()
         with:
           files: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,10 +109,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3.2
 
       - name: Set Kubernetes context
-        uses: azure/k8s-set-context@v3
+        uses: azure/k8s-set-context@38d6bc72e5877b8eb640e995218d42b8fedf1a47 # v3.1
         with:
           method: kubeconfig
           kubeconfig: ${{ secrets.KUBECONFIG }}

--- a/.github/workflows/test-pnpm.yml
+++ b/.github/workflows/test-pnpm.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '22'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
         with:
           version: 10.10.0
           run_install: false


### PR DESCRIPTION
This change updates the following GitHub Actions to use specific commit SHAs instead of tags:

- pnpm/action-setup@v3 to pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d (v3.0.0)
- azure/setup-kubectl@v3 to azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 (v3.2)
- azure/k8s-set-context@v3 to azure/k8s-set-context@38d6bc72e5877b8eb640e995218d42b8fedf1a47 (v3.1)
- EnricoMi/publish-unit-test-result-action@v2 to EnricoMi/publish-unit-test-result-action@afb2984f4d89672b2f9d9c13ae23d53779671984 (v2.19.0)

Pinning to commit SHAs enhances security by mitigating the risk of supply chain attacks where a tag could be maliciously updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated automated workflow actions to use specific version references for improved reliability and consistency. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->