### PR TITLE
chore: Update issue-labeler.yml

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/issue-labeler-config.yml
+          enable-versioned-regex: false # or true, depending on your needs


### PR DESCRIPTION
Enable versioned regex false

This pull request introduces a small configuration update to the GitHub Actions workflow for issue labeling. The change adds a new parameter, `enable-versioned-regex`, to the `jobs:` section of the `.github/workflows/issue-labeler.yml` file.

* [`.github/workflows/issue-labeler.yml`](diffhunk://#diff-90feb308f0997073f6f3c683330ff8007db17f3030525aefb3ce13a037648904R19): Added the `enable-versioned-regex` parameter to control whether versioned regular expressions are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to include a new configuration option for issue labeling. This allows toggling versioned regex matching for issue labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->